### PR TITLE
Autoattributes update

### DIFF
--- a/messen/autoattributes.py
+++ b/messen/autoattributes.py
@@ -3,30 +3,30 @@ import re
 from qgis.core import QgsFeatureRequest, QgsVectorLayer, QgsProject
 
 
-def getComboboxModelFromLayerConfig(layer: QgsVectorLayer, field_name: str, current_values: dict = None) -> dict:
-    if not current_values:
-        current_values = {}
-    field_idx = layer.fields().indexFromName(field_name)
-    if field_idx == -1:
-        print(f"Field '{field_name}' not found in layer '{layer.name()}'.")
+def getComboboxModelFromLayerConfig(layer: QgsVectorLayer, fieldName: str, currentValues: dict = None) -> dict:
+    if not currentValues:
+        currentValues = {}
+    fieldIdx = layer.fields().indexFromName(fieldName)
+    if fieldIdx == -1:
+        print(f"Field '{fieldName}' not found in layer '{layer.name()}'.")
         return {}
-    editor_config = layer.fields().field(field_idx).editorWidgetSetup().config()
-    if not editor_config:
-        print(f"No editor config found for field '{field_name}' in layer '{layer.name()}'.")
+    editorConfig = layer.fields().field(fieldIdx).editorWidgetSetup().config()
+    if not editorConfig:
+        print(f"No editor config found for field '{fieldName}' in layer '{layer.name()}'.")
         return {}
-    layer_id = editor_config["Layer"]
-    key_field = editor_config["Key"]
-    value_field = editor_config["Value"]
-    layer_filter_expression = editor_config.get("FilterExpression", "")
-    filter_expression = replace_current_values(layer_filter_expression, current_values)
-    rel_layer = QgsProject.instance().mapLayer(layer_id)
-    if not rel_layer:
-        print(f"Related layer with ID '{layer_id}' not found in the project.")
+    layerId = editorConfig["Layer"]
+    keyField = editorConfig["Key"]
+    valueField = editorConfig["Value"]
+    layerFilterExpression = editorConfig.get("FilterExpression", "")
+    filterExpression = replaceCurrentValues(layerFilterExpression, currentValues)
+    relLayer = QgsProject.instance().mapLayer(layerId)
+    if not relLayer:
+        print(f"Related layer with ID '{layerId}' not found in the project.")
         return {}
-    return getLookupDict(rel_layer, key_field, value_field, filter_expression)
+    return getLookupDict(relLayer, keyField, valueField, filterExpression)
 
 
-def replace_current_values(expr: str, values: dict) -> str:
+def replaceCurrentValues(expr: str, values: dict) -> str:
     """Replaces occurrences of current_value('field_name') in the expression with the corresponding value from the
     values dictionary {'field_name': value}. Values can be None, int, float, or str.
     Introduced to handle expressions that include current_value() and deal with the optional whitespace.

--- a/messen/autoattributes.py
+++ b/messen/autoattributes.py
@@ -1,0 +1,48 @@
+import re
+
+from qgis.core import QgsVectorLayer, QgsProject
+
+from ..utils.functions import getLookupDict
+
+
+def getComboboxModelFromLayerConfig(layer: QgsVectorLayer, field_name: str, current_values: dict = None) -> dict:
+    if not current_values:
+        current_values = {}
+    field_idx = layer.fields().indexFromName(field_name)
+    if field_idx == -1:
+        print(f"Field '{field_name}' not found in layer '{layer.name()}'.")
+        return {}
+    editor_config = layer.fields().field(field_idx).editorWidgetSetup().config()
+    if not editor_config:
+        print(f"No editor config found for field '{field_name}' in layer '{layer.name()}'.")
+        return {}
+    layer_id = editor_config["Layer"]
+    key_field = editor_config["Key"]
+    value_field = editor_config["Value"]
+    layer_filter_expression = editor_config.get("FilterExpression", "")
+    filter_expression = replace_current_values(layer_filter_expression, current_values)
+    rel_layer = QgsProject.instance().mapLayer(layer_id)
+    if not rel_layer:
+        print(f"Related layer with ID '{layer_id}' not found in the project.")
+        return {}
+    return getLookupDict(rel_layer, key_field, value_field, filter_expression)
+
+
+def replace_current_values(expr: str, values: dict) -> str:
+    """Replaces occurrences of current_value('field_name') in the expression with the corresponding value from the
+    values dictionary {'field_name': value}. Values can be None, int, float, or str.
+    Introduced to handle expressions that include current_value() and deal with the optional whitespace.
+    """
+    _PATTERN = re.compile(
+        r"current_value?\s*\(\s*(['\"])(?P<field_name>[^'\"]+)\1\s*\)",
+        re.IGNORECASE,
+    )
+
+    def quote(v):
+        if v is None:
+            return "NULL"
+        if isinstance(v, (int, float)):
+            return str(v)
+        return "'" + str(v).replace("'", "''") + "'"
+
+    return _PATTERN.sub(lambda m: quote(values.get(m.group("field_name"))), expr or "")

--- a/messen/autoattributes.py
+++ b/messen/autoattributes.py
@@ -14,14 +14,14 @@ def getComboboxModelFromLayerConfig(layer: QgsVectorLayer, fieldName: str, curre
     if not editorConfig:
         print(f"No editor config found for field '{fieldName}' in layer '{layer.name()}'.")
         return {}
-    layerId = editorConfig["Layer"]
+    layerName = editorConfig["LayerName"]
     keyField = editorConfig["Key"]
     valueField = editorConfig["Value"]
     layerFilterExpression = editorConfig.get("FilterExpression", "")
     filterExpression = replaceCurrentValues(layerFilterExpression, currentValues)
-    relLayer = QgsProject.instance().mapLayer(layerId)
+    relLayer = findLayerInProject(layerName)
     if not relLayer:
-        print(f"Related layer with ID '{layerId}' not found in the project.")
+        print(f"Related layer '{layerName}' not found in the project.")
         return {}
     return getLookupDict(relLayer, keyField, valueField, filterExpression)
 
@@ -54,5 +54,6 @@ def getLookupDict(layer, keyColumn, valueColumn, filterExpression=""):
     if filterExpression:
         request.setFilterExpression(filterExpression)
     for feature in layer.getFeatures(request):
-        lookupDict[feature.attribute(keyColumn)] = feature.attribute(valueColumn)
+        if feature.attribute(valueColumn) != QVariant():
+            lookupDict[feature.attribute(keyColumn)] = feature.attribute(valueColumn)
     return lookupDict

--- a/messen/autoattributes.py
+++ b/messen/autoattributes.py
@@ -1,6 +1,36 @@
 import re
 
-from qgis.core import QgsFeatureRequest, QgsVectorLayer, QgsProject
+from qgis.core import QgsFeatureRequest, QgsVectorLayer
+from qgis.PyQt.QtCore import QVariant
+
+from ..utils.functions import findLayerInProject, setCustomProjectVariable
+
+
+autoAttributeProjectVariables = [
+    "obj_typ_polygons",
+    "obj_art_polygons",
+    "obj_spez_polygons",
+    "obj_typ_lines",
+    "obj_art_lines",
+    "obj_typ_points",
+    "obj_art_points",
+    "schnitt_nr",
+    "planum_nr",
+    "bef_nr",
+    "prof_nr",
+    "pt_nr",
+    "fund_nr",
+    "probe_nr",
+    "material",
+    "material_zwei",
+    "zeit",
+    "zeit_zwei",
+]
+
+
+def clearAutoAttributeProjectVariables():
+    for autoAttributeName in autoAttributeProjectVariables:
+        setCustomProjectVariable(autoAttributeName, None)
 
 
 def getComboboxModelFromLayerConfig(layer: QgsVectorLayer, fieldName: str, currentValues: dict = None) -> dict:

--- a/messen/autoattributes.py
+++ b/messen/autoattributes.py
@@ -1,8 +1,6 @@
 import re
 
-from qgis.core import QgsVectorLayer, QgsProject
-
-from ..utils.functions import getLookupDict
+from qgis.core import QgsFeatureRequest, QgsVectorLayer, QgsProject
 
 
 def getComboboxModelFromLayerConfig(layer: QgsVectorLayer, field_name: str, current_values: dict = None) -> dict:
@@ -46,3 +44,15 @@ def replace_current_values(expr: str, values: dict) -> str:
         return "'" + str(v).replace("'", "''") + "'"
 
     return _PATTERN.sub(lambda m: quote(values.get(m.group("field_name"))), expr or "")
+
+
+def getLookupDict(layer, keyColumn, valueColumn, filterExpression=""):
+    lookupDict = {}
+    if layer.fields().indexOf(keyColumn) == -1 or layer.fields().indexOf(valueColumn) == -1:
+        return lookupDict
+    request = QgsFeatureRequest()
+    if filterExpression:
+        request.setFilterExpression(filterExpression)
+    for feature in layer.getFeatures(request):
+        lookupDict[feature.attribute(keyColumn)] = feature.attribute(valueColumn)
+    return lookupDict

--- a/messen/messen.py
+++ b/messen/messen.py
@@ -46,8 +46,8 @@ from ..utils.functions import (
     setCustomProjectVariable,
     showAndHideWidgets,
 )
-from .autoattributes import getComboboxModelFromLayerConfig
 from ..utils.toolbar_functions import saveProject
+from .autoattributes import getComboboxModelFromLayerConfig, clearAutoAttributeProjectVariables
 
 polygonsLayerName = "E_Polygon"
 linesLayerName = "E_Line"
@@ -59,29 +59,12 @@ connectedSignalsDict = {}
 
 WIDGET, BASE = uic.loadUiType(os.path.join(os.path.dirname(__file__), "messen.ui"))
 
-projectVariables = [
-    "obj_typ_polygons",
-    "obj_art_polygons",
-    "obj_spez_polygons",
-    "obj_typ_lines",
-    "obj_art_lines",
-    "obj_typ_points",
-    "obj_art_points",
-    "schnitt_nr",
-    "planum_nr",
-    "zbs",
-    "prof_nr",
-    "pt_nr",
-    "fund_nr",
-    "probe_nr",
-]
-
 
 class MeasurementTab(BASE, WIDGET):
     cmbLayerType: QComboBox
     schnitt_nr: QLineEdit
     planum_nr: QLineEdit
-    zbs: QLineEdit
+    bef_nr: QLineEdit
     prof_nr: QLineEdit
     pt_nr: QLineEdit
     fund_nr: QLineEdit
@@ -192,7 +175,7 @@ class MeasurementTab(BASE, WIDGET):
         self.cbActivateAutoAttributes.stateChanged.connect(self.setAutoAttributeMode)
         self.schnitt_nr.editingFinished.connect(partial(self.onLineEditingFinished, self.schnitt_nr))
         self.planum_nr.editingFinished.connect(partial(self.onLineEditingFinished, self.planum_nr))
-        self.zbs.editingFinished.connect(partial(self.onLineEditingFinished, self.zbs))
+        self.bef_nr.editingFinished.connect(partial(self.onLineEditingFinished, self.bef_nr))
         self.prof_nr.editingFinished.connect(partial(self.onLineEditingFinished, self.prof_nr))
         self.pt_nr.editingFinished.connect(partial(self.onLineEditingFinished, self.pt_nr))
         self.fund_nr.editingFinished.connect(partial(self.onLineEditingFinished, self.fund_nr))
@@ -551,7 +534,7 @@ class MeasurementTab(BASE, WIDGET):
         self.cmbObjectType_3.setCurrentIndex(0)
         self.schnitt_nr.clear()
         self.planum_nr.clear()
-        self.zbs.clear()
+        self.bef_nr.clear()
         self.prof_nr.clear()
         self.pt_nr.clear()
         self.fund_nr.clear()
@@ -924,10 +907,10 @@ class MeasurementTab(BASE, WIDGET):
 
     # ToDo: refactoring
     def nextValues(self):
-        if self.zbs.text() != "":
+        if self.bef_nr.text() != "":
             try:
-                if int(self.zbs.text()) >= int(self.txtNextBef.text()) and not "_" in self.zbs.text():
-                    self.txtNextBef.setText(str(int(self.zbs.text()) + 1))
+                if int(self.bef_nr.text()) >= int(self.txtNextBef.text()) and not "_" in self.bef_nr.text():
+                    self.txtNextBef.setText(str(int(self.bef_nr.text()) + 1))
             except Exception as e:
                 QgsMessageLog.logMessage(
                     message="MeasurementTab->nextValues: no setText: " + str(e),

--- a/messen/messen.py
+++ b/messen/messen.py
@@ -39,13 +39,13 @@ from ..Icons import ICON_PATHS
 from ..utils.functions import (
     enableAndDisableWidgets,
     getCustomProjectVariable,
-    getLookupDict,
     HelpWindow,
     findLayerInProject,
     layerHasPendingChanges,
     setCustomProjectVariable,
     showAndHideWidgets,
 )
+from .autoattributes import getComboboxModelFromLayerConfig
 from ..utils.toolbar_functions import saveProject
 
 polygonsLayerName = "E_Polygon"
@@ -561,9 +561,7 @@ class MeasurementTab(BASE, WIDGET):
         self.cmbObjectType_1.clear()
         self.cmbObjectType_2.clear()
         self.cmbObjectType_3.clear()
-        geom_typ = int(self.layerToEdit.geometryType())
-        s1_layer = QgsProject.instance().mapLayersByName("obj_type_s1")[0]
-        obj_types = getLookupDict(s1_layer, "class_id", "s1", f"geom_typ = {geom_typ}")
+        obj_types = getComboboxModelFromLayerConfig(self.layerToEdit, "obj_typ")
         self.cmbObjectType_1.addItem("", None)
         for fid, description in obj_types.items():
             self.cmbObjectType_1.addItem(description, fid)
@@ -573,9 +571,9 @@ class MeasurementTab(BASE, WIDGET):
         self.cmbObjectType_2.blockSignals(True)
         self.cmbObjectType_2.clear()
         self.cmbObjectType_3.clear()
-        s1_fid = self.cmbObjectType_1.currentData()
-        s2_layer = QgsProject.instance().mapLayersByName("obj_type_s2")[0]
-        obj_types = getLookupDict(s2_layer, "fid", "s2", f"obj_type_relation_s1_s2_s1_class_id = {s1_fid}")
+        obj_types = getComboboxModelFromLayerConfig(
+            self.layerToEdit, "obj_art", {"obj_typ": self.cmbObjectType_1.currentData()}
+        )
         self.cmbObjectType_2.addItem("", None)
         for fid, description in obj_types.items():
             self.cmbObjectType_2.addItem(description, fid)
@@ -584,9 +582,12 @@ class MeasurementTab(BASE, WIDGET):
     def fillComboObjectSpez(self):
         self.cmbObjectType_3.blockSignals(True)
         self.cmbObjectType_3.clear()
-        s2_fid = self.cmbObjectType_2.currentData()
-        s3_layer = QgsProject.instance().mapLayersByName("obj_type_s3")[0]
-        obj_types = getLookupDict(s3_layer, "fid", "s3", f"obj_type_relation_s2_s3_fid_s2 = {s2_fid}")
+
+        obj_types = getComboboxModelFromLayerConfig(
+            self.layerToEdit,
+            "obj_spez",
+            {"obj_typ": self.cmbObjectType_1.currentData(), "obj_art": self.cmbObjectType_2.currentData()},
+        )
         self.cmbObjectType_3.addItem("", None)
         for fid, description in obj_types.items():
             self.cmbObjectType_3.addItem(description, fid)

--- a/messen/messen.py
+++ b/messen/messen.py
@@ -934,7 +934,7 @@ class MeasurementTab(BASE, WIDGET):
                     tag="T2G Archäologie",
                     level=Qgis.MessageLevel.Warning,
                 )
-        if self.fund_nr.txtFundNr.text() != "":
+        if self.fund_nr.text() != "":
             try:
                 if int(self.fund_nr.text()) >= int(self.txtNextFund.text() and not "_" in self.fund_nr.text()):
                     self.txtNextFund.setText(str(int(self.fund_nr.text()) + 1))

--- a/messen/messen.py
+++ b/messen/messen.py
@@ -1,6 +1,7 @@
 import math
 import os
 import uuid
+from contextlib import contextmanager
 from datetime import date, datetime
 from functools import partial
 
@@ -171,6 +172,10 @@ class MeasurementTab(BASE, WIDGET):
         self.cmbObjectType_1.currentIndexChanged.connect(self.comboObjectTypeChanged)
         self.cmbObjectType_2.currentIndexChanged.connect(self.comboObjectArtChanged)
         self.cmbObjectType_3.currentIndexChanged.connect(self.comboObjectSpezChanged)
+        self.cmbMaterial.currentIndexChanged.connect(self.comboMaterialChanged)
+        self.cmbMaterial2.currentIndexChanged.connect(self.comboMaterial2Changed)
+        self.cmbZeit.currentIndexChanged.connect(self.comboZeitChanged)
+        self.cmbZeit2.currentIndexChanged.connect(self.comboZeit2Changed)
         self.btnResetAutoAttributes.clicked.connect(self.resetAutoAttributeValues)
         self.cbActivateAutoAttributes.stateChanged.connect(self.setAutoAttributeMode)
         self.schnitt_nr.editingFinished.connect(partial(self.onLineEditingFinished, self.schnitt_nr))
@@ -471,31 +476,20 @@ class MeasurementTab(BASE, WIDGET):
             self.actionDigitize.setText("Punkte zeichnen")
             showAndHideWidgets([self.qgsGroupBoxAttributes], [self.widgetCmbPolygonDigitizingMode])
         self.geometryType = geometryType
-        self.setAttributes()
+        self.adjustAutoAttributes()
         self.startTachyWatch()
 
     def setAutoAttributeMode(self, state: int):
         setCustomProjectVariable("autoAttribute", bool(state))
 
-    def clearObjectCombos(self):
-        self.cmbObjectType_1.blockSignals(True)
-        self.cmbObjectType_2.blockSignals(True)
-        self.cmbObjectType_3.blockSignals(True)
-        self.cmbObjectType_1.clear()
-        self.cmbObjectType_2.clear()
-        self.cmbObjectType_3.clear()
-        self.cmbObjectType_1.blockSignals(False)
-        self.cmbObjectType_2.blockSignals(False)
-        self.cmbObjectType_3.blockSignals(False)
-
-    def setAttributes(self):
-        self.clearObjectCombos()
+    def adjustAutoAttributes(self):
         self.fillComboObjectType()
+        if not self.cmbMaterial.count():
+            self.fillComboMaterial()
+        if not self.cmbZeit.count():
+            self.fillComboZeit()
 
-        if self.geometryType != "polygons":
-            self.cmbObjectType_3.hide()
-        else:
-            self.cmbObjectType_3.show()
+        self.cmbObjectType_3.setEnabled(self.geometryType == "polygons")
 
         objTypeGeometry = getCustomProjectVariable(f"obj_typ_{self.geometryType}")
         if objTypeGeometry:
@@ -523,9 +517,29 @@ class MeasurementTab(BASE, WIDGET):
     def comboObjectSpezChanged(self):
         setCustomProjectVariable(f"obj_spez_{self.geometryType}", self.cmbObjectType_3.currentData())
 
+    def comboMaterialChanged(self):
+        setCustomProjectVariable("material", self.cmbMaterial.currentData())
+        self.fillComboMaterial2()
+
+        material2 = getCustomProjectVariable("material_zwei")
+        if material2:
+            self.cmbMaterial2.setCurrentIndex(self.cmbMaterial2.findData(material2))
+
+    def comboMaterial2Changed(self):
+        setCustomProjectVariable("material_zwei", self.cmbMaterial2.currentData())
+
+    def comboZeitChanged(self):
+        setCustomProjectVariable("zeit", self.cmbZeit.currentData())
+        self.fillComboZeit2()
+
+        zeit2 = getCustomProjectVariable("zeit_zwei")
+        if zeit2:
+            self.cmbZeit2.setCurrentIndex(self.cmbZeit2.findData(zeit2))
+
+    def comboZeit2Changed(self):
+        setCustomProjectVariable("zeit_zwei", self.cmbZeit2.currentData())
+
     def resetAutoAttributeValues(self):
-        for variable in projectVariables:
-            setCustomProjectVariable(variable, "")
         self.cmbObjectType_1.setCurrentIndex(0)
         self.cmbObjectType_2.setCurrentIndex(0)
         self.cmbObjectType_3.setCurrentIndex(0)
@@ -536,43 +550,108 @@ class MeasurementTab(BASE, WIDGET):
         self.pt_nr.clear()
         self.fund_nr.clear()
         self.probe_nr.clear()
+        self.cmbMaterial.setCurrentIndex(0)
+        self.cmbMaterial2.setCurrentIndex(0)
+        self.cmbZeit.setCurrentIndex(0)
+        self.cmbZeit2.setCurrentIndex(0)
+
+        clearAutoAttributeProjectVariables()
+
+    @contextmanager
+    def blockSignalsObjTypes(self):
+        self.cmbObjectType_1.blockSignals(True)
+        self.cmbObjectType_2.blockSignals(True)
+        self.cmbObjectType_3.blockSignals(True)
+        try:
+            yield
+        finally:
+            self.cmbObjectType_1.blockSignals(False)
+            self.cmbObjectType_2.blockSignals(False)
+            self.cmbObjectType_3.blockSignals(False)
 
     def fillComboObjectType(self):
-        self.cmbObjectType_1.blockSignals(True)
-        self.cmbObjectType_1.clear()
-        self.cmbObjectType_2.clear()
-        self.cmbObjectType_3.clear()
-        obj_types = getComboboxModelFromLayerConfig(self.layerToEdit, "obj_typ")
-        self.cmbObjectType_1.addItem("", None)
-        for fid, description in obj_types.items():
-            self.cmbObjectType_1.addItem(description, fid)
-        self.cmbObjectType_1.blockSignals(False)
+        with self.blockSignalsObjTypes():
+            self.cmbObjectType_1.clear()
+            self.cmbObjectType_2.clear()
+            self.cmbObjectType_3.clear()
+            obj_types = getComboboxModelFromLayerConfig(self.layerToEdit, "obj_typ")
+            self.cmbObjectType_1.addItem("", None)
+            for fid, description in obj_types.items():
+                self.cmbObjectType_1.addItem(description, fid)
 
     def fillComboObjectArt(self):
-        self.cmbObjectType_2.blockSignals(True)
-        self.cmbObjectType_2.clear()
-        self.cmbObjectType_3.clear()
-        obj_types = getComboboxModelFromLayerConfig(
-            self.layerToEdit, "obj_art", {"obj_typ": self.cmbObjectType_1.currentData()}
-        )
-        self.cmbObjectType_2.addItem("", None)
-        for fid, description in obj_types.items():
-            self.cmbObjectType_2.addItem(description, fid)
-        self.cmbObjectType_2.blockSignals(False)
+        with self.blockSignalsObjTypes():
+            self.cmbObjectType_2.clear()
+            self.cmbObjectType_3.clear()
+            obj_types = getComboboxModelFromLayerConfig(
+                self.layerToEdit, "obj_art", {"obj_typ": self.cmbObjectType_1.currentData()}
+            )
+            self.cmbObjectType_2.addItem("", None)
+            for fid, description in obj_types.items():
+                self.cmbObjectType_2.addItem(description, fid)
 
     def fillComboObjectSpez(self):
-        self.cmbObjectType_3.blockSignals(True)
-        self.cmbObjectType_3.clear()
+        with self.blockSignalsObjTypes():
+            self.cmbObjectType_3.clear()
 
-        obj_types = getComboboxModelFromLayerConfig(
+            obj_types = getComboboxModelFromLayerConfig(
+                self.layerToEdit,
+                "obj_spez",
+                {"obj_typ": self.cmbObjectType_1.currentData(), "obj_art": self.cmbObjectType_2.currentData()},
+            )
+            self.cmbObjectType_3.addItem("", None)
+            for fid, description in obj_types.items():
+                self.cmbObjectType_3.addItem(description, fid)
+
+    def fillComboMaterial(self):
+        self.cmbMaterial.blockSignals(True)
+        self.cmbMaterial2.clear()
+        self.cmbMaterial.clear()
+        materials = getComboboxModelFromLayerConfig(self.layerToEdit, "material")
+        self.cmbMaterial.addItem("", None)
+        for fid, description in materials.items():
+            if all((fid, description)):
+                self.cmbMaterial.addItem(description, fid)
+        self.cmbMaterial.blockSignals(False)
+
+    def fillComboMaterial2(self):
+        self.cmbMaterial2.blockSignals(True)
+        self.cmbMaterial2.clear()
+        materials = getComboboxModelFromLayerConfig(
             self.layerToEdit,
-            "obj_spez",
-            {"obj_typ": self.cmbObjectType_1.currentData(), "obj_art": self.cmbObjectType_2.currentData()},
+            "material_zwei",
+            {"material": self.cmbMaterial.currentData()},
         )
-        self.cmbObjectType_3.addItem("", None)
-        for fid, description in obj_types.items():
-            self.cmbObjectType_3.addItem(description, fid)
-        self.cmbObjectType_3.blockSignals(False)
+        self.cmbMaterial2.addItem("", None)
+        for fid, description in materials.items():
+            if all((fid, description)):
+                self.cmbMaterial2.addItem(description, fid)
+        self.cmbMaterial2.blockSignals(False)
+
+    def fillComboZeit(self):
+        self.cmbZeit.blockSignals(True)
+        self.cmbZeit2.clear()
+        self.cmbZeit.clear()
+        epochen = getComboboxModelFromLayerConfig(self.layerToEdit, "zeit")
+        self.cmbZeit.addItem("", None)
+        for fid, description in epochen.items():
+            if all((fid, description)):
+                self.cmbZeit.addItem(description, fid)
+        self.cmbZeit.blockSignals(False)
+
+    def fillComboZeit2(self):
+        self.cmbZeit2.blockSignals(True)
+        self.cmbZeit2.clear()
+        epochen = getComboboxModelFromLayerConfig(
+            self.layerToEdit,
+            "zeit_zwei",
+            {"zeit": self.cmbZeit.currentData()},
+        )
+        self.cmbZeit2.addItem("", None)
+        for fid, description in epochen.items():
+            if all((fid, description)):
+                self.cmbZeit2.addItem(description, fid)
+        self.cmbZeit2.blockSignals(False)
 
     def createMarkersAndRubberBand(self, geometryType):
         if geometryType == "polygons":

--- a/messen/messen.py
+++ b/messen/messen.py
@@ -4,12 +4,12 @@ import uuid
 from datetime import date, datetime
 from functools import partial
 
-from PyQt5.QtWidgets import QApplication
 from qgis.PyQt import uic
 from qgis.PyQt.QtCore import Qt, QTimer, QVariant
 from qgis.PyQt.QtGui import QColor, QCursor, QIcon, QKeySequence
 from qgis.PyQt.QtWidgets import (
     QAction,
+    QApplication,
     QComboBox,
     QLineEdit,
     QMenu,
@@ -30,7 +30,8 @@ from qgis.core import (
     QgsProject,
     QgsRectangle,
     QgsVectorLayerUtils,
-    QgsWkbTypes, QgsApplication,
+    QgsWkbTypes,
+    QgsApplication,
 )
 from qgis.gui import QgsMapTool, QgsSnapIndicator, QgsRubberBand, QgsVertexMarker
 from qgis.utils import iface, plugins

--- a/messen/messen.py
+++ b/messen/messen.py
@@ -474,11 +474,8 @@ class MeasurementTab(BASE, WIDGET):
         self.setAttributes()
         self.startTachyWatch()
 
-    def setAutoAttributeMode(self):
-        if self.cbActivateAutoAttributes.isChecked():
-            setCustomProjectVariable("autoAttribute", True)
-        else:
-            setCustomProjectVariable("autoAttribute", False)
+    def setAutoAttributeMode(self, state: int):
+        setCustomProjectVariable("autoAttribute", bool(state))
 
     def clearObjectCombos(self):
         self.cmbObjectType_1.blockSignals(True)

--- a/messen/messen.ui
+++ b/messen/messen.ui
@@ -169,9 +169,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>0</y>
-        <width>399</width>
-        <height>785</height>
+        <y>-442</y>
+        <width>378</width>
+        <height>1227</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -706,7 +706,7 @@
             <property name="maximumSize">
              <size>
               <width>16777215</width>
-              <height>22</height>
+              <height>16777215</height>
              </size>
             </property>
             <property name="title">
@@ -719,7 +719,7 @@
              <bool>false</bool>
             </property>
             <property name="collapsed">
-             <bool>true</bool>
+             <bool>false</bool>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_5">
              <property name="leftMargin">
@@ -749,32 +749,6 @@
               </widget>
              </item>
              <item>
-              <widget class="QWidget" name="widget_9" native="true">
-               <layout class="QVBoxLayout" name="verticalLayout_6">
-                <item>
-                 <widget class="QComboBox" name="cmbObjectType_1">
-                  <property name="sizeAdjustPolicy">
-                   <enum>QComboBox::AdjustToMinimumContentsLength</enum>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QComboBox" name="cmbObjectType_2"/>
-                </item>
-                <item>
-                 <widget class="QComboBox" name="cmbObjectType_3"/>
-                </item>
-               </layout>
-              </widget>
-             </item>
-             <item>
-              <widget class="QLabel" name="label_5">
-               <property name="text">
-                <string>Objekttyp</string>
-               </property>
-              </widget>
-             </item>
-             <item>
               <widget class="QWidget" name="widget_7" native="true">
                <layout class="QGridLayout" name="gridLayout_4">
                 <property name="leftMargin">
@@ -789,16 +763,76 @@
                 <property name="bottomMargin">
                  <number>0</number>
                 </property>
-                <item row="2" column="2">
-                 <widget class="QLineEdit" name="zbs"/>
-                </item>
-                <item row="3" column="2">
-                 <widget class="QLineEdit" name="prof_nr"/>
-                </item>
-                <item row="6" column="2">
+                <item row="9" column="2">
                  <widget class="QLineEdit" name="probe_nr"/>
                 </item>
+                <item row="0" column="2">
+                 <widget class="QComboBox" name="cmbObjectType_1">
+                  <property name="sizeAdjustPolicy">
+                   <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+                  </property>
+                 </widget>
+                </item>
+                <item row="10" column="0">
+                 <widget class="QLabel" name="label_19">
+                  <property name="text">
+                   <string>Material</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="7" column="2">
+                 <widget class="QLineEdit" name="pt_nr"/>
+                </item>
+                <item row="11" column="2">
+                 <widget class="QComboBox" name="cmbMaterial2"/>
+                </item>
+                <item row="6" column="2">
+                 <widget class="QLineEdit" name="prof_nr"/>
+                </item>
+                <item row="3" column="2">
+                 <widget class="QLineEdit" name="schnitt_nr"/>
+                </item>
                 <item row="3" column="0">
+                 <widget class="QLabel" name="label_12">
+                  <property name="text">
+                   <string>Schnitt</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="8" column="2">
+                 <widget class="QLineEdit" name="fund_nr"/>
+                </item>
+                <item row="1" column="0">
+                 <widget class="QLabel" name="label_22">
+                  <property name="text">
+                   <string>Objektart</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="5" column="2">
+                 <widget class="QLineEdit" name="bef_nr"/>
+                </item>
+                <item row="4" column="2">
+                 <widget class="QLineEdit" name="planum_nr"/>
+                </item>
+                <item row="12" column="0">
+                 <widget class="QLabel" name="label_20">
+                  <property name="text">
+                   <string>Epoche</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="2" column="2">
+                 <widget class="QComboBox" name="cmbObjectType_3"/>
+                </item>
+                <item row="11" column="0">
+                 <widget class="QLabel" name="label_21">
+                  <property name="text">
+                   <string>Material (2)</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="6" column="0">
                  <widget class="QLabel" name="label_15">
                   <property name="text">
                    <string>Profil</string>
@@ -806,78 +840,72 @@
                  </widget>
                 </item>
                 <item row="1" column="2">
-                 <widget class="QLineEdit" name="planum_nr"/>
+                 <widget class="QComboBox" name="cmbObjectType_2"/>
                 </item>
-                <item row="4" column="2">
-                 <widget class="QLineEdit" name="pt_nr"/>
-                </item>
-                <item row="4" column="0">
-                 <widget class="QLabel" name="label_16">
-                  <property name="text">
-                   <string>Punkt</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="2" column="0">
-                 <widget class="QLabel" name="label_14">
-                  <property name="text">
-                   <string>ZBS</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="5" column="0">
+                <item row="8" column="0">
                  <widget class="QLabel" name="label_17">
                   <property name="text">
                    <string>Fund</string>
                   </property>
                  </widget>
                 </item>
-                <item row="7" column="0">
-                 <widget class="QLabel" name="label_19">
+                <item row="2" column="0">
+                 <widget class="QLabel" name="label_23">
                   <property name="text">
-                   <string>Material</string>
+                   <string>Objektspez.</string>
                   </property>
                  </widget>
                 </item>
-                <item row="1" column="0">
-                 <widget class="QLabel" name="label_13">
-                  <property name="text">
-                   <string>Planum</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="0" column="2">
-                 <widget class="QLineEdit" name="schnitt_nr"/>
-                </item>
-                <item row="5" column="2">
-                 <widget class="QLineEdit" name="fund_nr"/>
-                </item>
-                <item row="7" column="2">
+                <item row="10" column="2">
                  <widget class="QComboBox" name="cmbMaterial"/>
                 </item>
-                <item row="6" column="0">
+                <item row="7" column="0">
+                 <widget class="QLabel" name="label_16">
+                  <property name="text">
+                   <string>Punkt</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="9" column="0">
                  <widget class="QLabel" name="label_18">
                   <property name="text">
                    <string>Probe</string>
                   </property>
                  </widget>
                 </item>
-                <item row="8" column="2">
-                 <widget class="QComboBox" name="cmbEpoche"/>
+                <item row="12" column="2">
+                 <widget class="QComboBox" name="cmbZeit"/>
+                </item>
+                <item row="4" column="0">
+                 <widget class="QLabel" name="label_13">
+                  <property name="text">
+                   <string>Planum</string>
+                  </property>
+                 </widget>
                 </item>
                 <item row="0" column="0">
-                 <widget class="QLabel" name="label_12">
+                 <widget class="QLabel" name="label_5">
                   <property name="text">
-                   <string>Schnitt</string>
+                   <string>Objekttyp</string>
                   </property>
                  </widget>
                 </item>
-                <item row="8" column="0">
-                 <widget class="QLabel" name="label_20">
+                <item row="5" column="0">
+                 <widget class="QLabel" name="label_14">
                   <property name="text">
-                   <string>Epoche</string>
+                   <string>ZBS</string>
                   </property>
                  </widget>
+                </item>
+                <item row="13" column="0">
+                 <widget class="QLabel" name="label_24">
+                  <property name="text">
+                   <string>Epoche (2)</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="13" column="2">
+                 <widget class="QComboBox" name="cmbZeit2"/>
                 </item>
                </layout>
               </widget>
@@ -1052,13 +1080,13 @@
   <tabstop>cbActivateAutoAttributes</tabstop>
   <tabstop>schnitt_nr</tabstop>
   <tabstop>planum_nr</tabstop>
-  <tabstop>zbs</tabstop>
+  <tabstop>bef_nr</tabstop>
   <tabstop>prof_nr</tabstop>
   <tabstop>pt_nr</tabstop>
   <tabstop>fund_nr</tabstop>
   <tabstop>probe_nr</tabstop>
   <tabstop>cmbMaterial</tabstop>
-  <tabstop>cmbEpoche</tabstop>
+  <tabstop>cmbZeit</tabstop>
   <tabstop>btnResetAutoAttributes</tabstop>
   <tabstop>cbSound</tabstop>
   <tabstop>btnHelp</tabstop>

--- a/utils/functions.py
+++ b/utils/functions.py
@@ -11,21 +11,20 @@ from datetime import datetime
 from pathlib import Path
 
 import yaml
-from PyQt5.QtCore import QRect, QCoreApplication
-from PyQt5.QtGui import QPainter, QIcon, QImage, QPixmap
-from PyQt5.QtSvg import QSvgRenderer
-from qgis.PyQt.QtCore import Qt, QUrl, pyqtSignal
-from qgis.PyQt.QtGui import QColor
+from qgis.PyQt.QtCore import pyqtSignal, QCoreApplication, QRect, Qt, QUrl
+from qgis.PyQt.QtGui import QColor, QPainter, QIcon, QImage, QPixmap
 from qgis.PyQt.QtWidgets import QDesktopWidget, QGridLayout, QMessageBox, QLabel, QProgressBar, QTextBrowser, QWidget
-from qgis._core import Qgis, QgsMessageLog
+from qgis.PyQt.QtSvg import QSvgRenderer
 from qgis.core import (
     QgsExpressionContextUtils,
     QgsFeature,
     QgsField,
     QgsGeometry,
+    Qgis,
     QgsLayerTreeGroup,
     QgsLayerTreeLayer,
     QgsMapLayer,
+    QgsMessageLog,
     QgsPoint,
     QgsPointXY,
     QgsProject,

--- a/utils/functions.py
+++ b/utils/functions.py
@@ -43,12 +43,12 @@ def is_network_path(path):
     # Convert to absolute path
     full_path = os.path.abspath(path)
     # For UNC paths, use the server/share root
-    if full_path.startswith('\\\\'):
+    if full_path.startswith("\\\\"):
         # UNC root would look like \\server\share
         # Typically extracting the first two path components after '\\'
-        parts = full_path.strip('\\').split('\\')
+        parts = full_path.strip("\\").split("\\")
         if len(parts) >= 2:
-            unc_root = '\\\\' + parts[0] + '\\' + parts[1]
+            unc_root = "\\\\" + parts[0] + "\\" + parts[1]
             drive_type = GetDriveTypeW(unc_root)
         else:
             # If we can't properly parse a UNC root, treat it carefully:
@@ -61,7 +61,7 @@ def is_network_path(path):
             # No drive means it's relative or otherwise ambiguous
             return False
         # Ensure drive ends with a backslash
-        drive_root = drive + '\\'
+        drive_root = drive + "\\"
         drive_type = GetDriveTypeW(drive_root)
 
     return drive_type == 4  # DRIVE_REMOTE
@@ -208,7 +208,7 @@ def project_backup(iface, subfolder: str, keep_only_last_n_backups: int = None):
     """
 
     strftime_format_string = "%Y-%m-%d_%H_%M_%S"
-    regex_pattern_for_format_string = r'\d{4}-\d{2}-\d{2}_\d{2}_\d{2}_\d{2}'
+    regex_pattern_for_format_string = r"\d{4}-\d{2}-\d{2}_\d{2}_\d{2}_\d{2}"
     sensible_layers = ["E_Point", "E_Line", "E_Polygon", "Messpunkte"]
 
     def delete_oldest_folders(directory, keep_num):
@@ -234,12 +234,12 @@ def project_backup(iface, subfolder: str, keep_only_last_n_backups: int = None):
             text=text,
             level=(Qgis.MessageLevel.Warning if critical else Qgis.MessageLevel.Info),
             # duration=(0 if critical else -1)
-            duration=(10 if critical else -1)
+            duration=(10 if critical else -1),
         )
         QgsMessageLog.logMessage(
             tag="T2G Archäologie",
             message="Backup: " + text,
-            level=(Qgis.MessageLevel.Warning if critical else Qgis.MessageLevel.Info)
+            level=(Qgis.MessageLevel.Warning if critical else Qgis.MessageLevel.Info),
         )
 
     show_message("starting ... please wait")
@@ -249,8 +249,7 @@ def project_backup(iface, subfolder: str, keep_only_last_n_backups: int = None):
 
     if not layers_not_in_edit_mode(sensible_layers) or project.isDirty():
         show_message(
-            "Nicht möglich. Bitte den Editiermodus der Eingabelayer beenden und die Projektdatei speichern.",
-            True
+            "Nicht möglich. Bitte den Editiermodus der Eingabelayer beenden und die Projektdatei speichern.", True
         )
         return False
 

--- a/utils/functions.py
+++ b/utils/functions.py
@@ -21,7 +21,6 @@ from qgis._core import Qgis, QgsMessageLog
 from qgis.core import (
     QgsExpressionContextUtils,
     QgsFeature,
-    QgsFeatureRequest,
     QgsField,
     QgsGeometry,
     QgsLayerTreeGroup,
@@ -145,18 +144,6 @@ def get_source_file_paths_of_layers(list_of_layer_names: list[str]):
 
 def natural_sort_key(s, _nsre=re.compile("([0-9]+)")):
     return [int(text) if text.isdigit() else text.lower() for text in _nsre.split(s)]
-
-
-def getLookupDict(layer, keyColumn, valueColumn, filterExpression=""):
-    lookupDict = {}
-    if layer.fields().indexOf(keyColumn) == -1 or layer.fields().indexOf(valueColumn) == -1:
-        return lookupDict
-    request = QgsFeatureRequest()
-    if filterExpression:
-        request.setFilterExpression(filterExpression)
-    for feature in layer.getFeatures(request):
-        lookupDict[feature.attribute(keyColumn)] = feature.attribute(valueColumn)
-    return lookupDict
 
 
 def setCustomProjectVariable(variableName, variableWert):

--- a/utils/t2g_arch.py
+++ b/utils/t2g_arch.py
@@ -279,14 +279,11 @@ class T2gArch:
             it = layer.getFeatures(QgsFeatureRequest().setFilterExpression('"uuid" IS NULL'))
             QgsMessageLog.logMessage(
                 f"{sum(1 for _ in it)} features ohne UUID in Layer {layer.name()}; Neugenerierung ...",
-                'T2G Archäologie',
-                Qgis.Info
+                "T2G Archäologie",
+                Qgis.Info,
             )
             UUid = layer.dataProvider().fieldNameIndex("obj_uuid")
-            attr_map = {
-                feature.id(): {UUid: "{" + str(uuid.uuid4()) + "}"}
-                for feature in it
-            }
+            attr_map = {feature.id(): {UUid: "{" + str(uuid.uuid4()) + "}"} for feature in it}
             layer.dataProvider().changeAttributeValues(attr_map)
             layer.commitChanges()
         # <uuid ereugen wenn Feld uuid leer
@@ -404,7 +401,7 @@ class T2gArch:
                         "Das geladene QGIS-Projekt entspricht nicht der vorgegebenen Projektstruktur.\n"
                         "Es können Fehler oder ein Datenverlust auftreten!\n\n"
                         f"Fehler:\n{answer}"
-                    )
+                    ),
                 )
                 return False
 
@@ -880,12 +877,10 @@ class T2gArch:
             # and then periodically
             autoSaveTime = ArchProjectConfig().get("AutoSave_interval_in_min")
             self.watch.start(int(autoSaveTime) * 60000)
-            QgsMessageLog.logMessage(
-                f"Auto Backup: An, Takt {autoSaveTime} min", 'T2G Archäologie', Qgis.Info)
+            QgsMessageLog.logMessage(f"Auto Backup: An, Takt {autoSaveTime} min", "T2G Archäologie", Qgis.Info)
         else:
             self.watch.stop()
-            QgsMessageLog.logMessage(
-                "Auto Backup: Aus", 'T2G Archäologie', Qgis.Info)
+            QgsMessageLog.logMessage("Auto Backup: Aus", "T2G Archäologie", Qgis.Info)
 
     def eventFeatureAdded(self, fid):
         # Wird nirgends mehr verwendet # Sonst Fehler beim Digitalisieren
@@ -1478,9 +1473,7 @@ class T2gArch:
                 f"{metadata['description']}\n{metadata['name']} V{metadata['version_installed']} für QGIS 3.40\n{metadata['author_email']}"
             )
         else:
-            dialog_ui.label_version.setText(
-                f"Error: QGIS didn't load plugin metadata!!!"
-            )
+            dialog_ui.label_version.setText(f"Error: QGIS didn't load plugin metadata!!!")
         del metadata
 
         dialog.exec()
@@ -1502,9 +1495,7 @@ class T2gArch:
 
         if self.number_of_unsuccessful_auto_backups > 1:
 
-            zeit = self.number_of_unsuccessful_auto_backups * int(
-                ArchProjectConfig().get("AutoSave_interval_in_min")
-            )
+            zeit = self.number_of_unsuccessful_auto_backups * int(ArchProjectConfig().get("AutoSave_interval_in_min"))
             result = QMessageBox.question(
                 None,
                 "Jetzt speichern und Backup erstellen?",
@@ -1724,9 +1715,9 @@ class T2gArch:
             formula = field.defaultValueDefinition().expression()
             if formula != 'if (count("fid") = 0, 0, maximum("fid") + 1)':
                 return (
-                    f'in layer {layer.name()} fid default value definition is not '
+                    f"in layer {layer.name()} fid default value definition is not "
                     f'if (count("fid") = 0, 0, maximum("fid") + 1) '
-                    f'actual value: {formula}'
+                    f"actual value: {formula}"
                 )
 
             general_geom = geometry_types_per_layer[layer_name][0]

--- a/utils/t2g_arch.py
+++ b/utils/t2g_arch.py
@@ -86,6 +86,7 @@ from ..ExtDialoge.myDlgSettings import DlgSettings, Configfile
 from ..Icons import ICON_PATHS
 from ..geoEdit.geo_edit import GeoEdit
 from ..messen.messen import MeasurementTab
+from ..messen.autoattributes import clearAutoAttributeProjectVariables
 from ..profile.profile import Profile
 from ..transformation.transformation_gui import TransformationGui
 
@@ -258,7 +259,7 @@ class T2gArch:
     def setup(self):
         self.iface.setActiveLayer(self.layerPoly)
 
-        self.currentLayerChanged()
+        self.initProjectVariables()
         self.getMaxValues()
 
         QgsMessageLog.logMessage("Aufsatz Archäologie für T2G ist einsatzbereit.", self.plugin_name_tag, Qgis.Info)
@@ -950,22 +951,10 @@ class T2gArch:
                 self.measurementTab.txtNextProb.setText("xxxxx")
                 # QgsMessageLog.logMessage('Filter gesetzt', 'T2G Archäologie', Qgis.Info)
 
-    # ToDo: refactoring - consistent with auto attributes in Tab "Vermessung"?
-    def currentLayerChanged(self):
-        setCustomProjectVariable("obj_typ", "")
-        setCustomProjectVariable("obj_art", "")
-        setCustomProjectVariable("schnitt_nr", "")
-        setCustomProjectVariable("bef_nr", "")
-        setCustomProjectVariable("planum_nr", "")
-        setCustomProjectVariable("fund_nr", "")
-        setCustomProjectVariable("prob_nr", "")
-        setCustomProjectVariable("prof_nr", "")
-        setCustomProjectVariable("material", "")
-        setCustomProjectVariable("pt_nr", "")
-        setCustomProjectVariable("autoAttribute", "False")
-        setCustomProjectVariable("autoZahl", "False")
+    def initProjectVariables(self):
+        clearAutoAttributeProjectVariables()
+        setCustomProjectVariable("autoAttribute", False)
         setCustomProjectVariable("maxWerteAktualisieren", True)
-        setCustomProjectVariable("SignalGeometrieNeu", "False")
 
     # ToDo: refactoring - tab: "Tools Raster"
     def setCutMask(self):


### PR DESCRIPTION
- Bugfixes
- Autoattributfunktion für weitere Attribute: material, material_zwei, zeit und zeit_zwei
- Aktualisierungen im QGIS Projekt nötig (wenn Autoattributfunktion genutzt werden soll): Einstellung der Defaultwerte nach dem Muster  `if( @autoAttribute,  @prof_nr , NULL ) ` Die Variablen heissen jetzt konsequent wie die Attributfelder mit Ausnahme von Objekttyp, -art und -spez. Diese werden wie gehabt je Geometrietyp gespeichert und lauten `obj_typ_polygons`, `obj_art_polygons`, `obj_spez_polygons` bzw mit suffix `_lines` und `_points`